### PR TITLE
1c - removing https security group policy - single instance only

### DIFF
--- a/.ebextensions/https-instance-securitygroup.config
+++ b/.ebextensions/https-instance-securitygroup.config
@@ -1,9 +1,0 @@
-Resources:
-  sslSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: {"Fn::Get" : ["awseb-e-fupsj9pguw-stack-AWSEBSecurityGroup-1BAY6O6GP5RU", "sg-0c99312bd8d76acf3"]}
-      InProtocol: tcp
-      ToPort: 443
-      FromPort: 443
-      CidrIp: 0.0.0.0/0


### PR DESCRIPTION
Removing security group policy not required as single instance EBS->EC2 instances not supported by certs unless I register a domain url which I am not doing to do. Demo purposes does for the pipeline is not justifying buying a domain url for it. aws domain requires a proxy workaround that does not add to the CICD focus of the project.